### PR TITLE
Add initial support for macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The *gorfc* package provides bindings for *SAP NW RFC Library*, for a comfortable way of calling remote enabled ABAP function modules (RFMs) from [Go](https://golang.org).
 
-The current release is fully functional on Linux and experimental on Windows, see the [Issue #1](https://github.com/SAP/gorfc/issues/1).
+The current release is fully functional on Linux and experimental on Windows and macOS see the [Issue #1](https://github.com/SAP/gorfc/issues/1).
 
 ## Table of contents
 
@@ -21,7 +21,7 @@ The current release is fully functional on Linux and experimental on Windows, se
 
 ## Platforms and Prerequisites
 
-The SAP NW RFC Library is a prerequisite for using the Go RFC connector and must be installed on the same system. It is available on many platforms supported by Go, except macOS, Plan 9 and BSD.
+The SAP NW RFC Library is a prerequisite for using the Go RFC connector and must be installed on the same system. It is available on many platforms supported by Go, except Plan 9 and BSD.
 
 A prerequisite to download *SAP NW RFC Library* is having a **customer or partner account** on *SAP Service Marketplace* . If you are SAP employee please check SAP OSS note [1037575 - Software download authorizations for SAP employees](http://service.sap.com/sap/support/notes/1037575).
 

--- a/gorfc/gorfc.go
+++ b/gorfc/gorfc.go
@@ -33,6 +33,17 @@ package gorfc
 #cgo windows LDFLAGS: -m64 -fexceptions -funsigned-char -Wall -Wno-uninitialized -Wno-long-long
 #cgo windows LDFLAGS: -Wcast-align
 
+#cgo darwin LDFLAGS: -lsapnwrfc -lsapucum
+#cgo darwin LDFLAGS: -O2 -minline-all-stringops -g -fno-strict-aliasing -fno-omit-frame-pointer
+#cgo darwin LDFLAGS: -m64 -fexceptions -funsigned-char -Wall -Wno-uninitialized -Wno-long-long
+#cgo darwin LDFLAGS: -Wcast-align -pthread
+
+#cgo darwin CFLAGS: -DNDEBUG -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DSAPonUNIX
+#cgo darwin CFLAGS: -DSAPwithUNICODE -D__NO_MATH_INLINES -DSAPwithTHREADS -DSAPonDARW
+#cgo darwin CFLAGS: -O2 -minline-all-stringops -g -fno-strict-aliasing -fno-omit-frame-pointer
+#cgo darwin CFLAGS: -m64 -fexceptions  -Wall -Wno-uninitialized -Wno-long-long
+#cgo darwin CFLAGS: -Wcast-align -pthread -pipe -Wno-unused-variable
+
 #include <sapnwrfc.h>
 
 static SAP_UC* GoMallocU(unsigned size) {
@@ -277,7 +288,7 @@ func nWrapString(uc *C.SAP_UC, length C.int, strip bool) (result string, err err
 
 	*utf8str = 0
 	resultLen := C.uint(0)
-	rc = C.RfcSAPUCToUTF8(uc, (C.uint)(length), (*C.RFC_BYTE)(utf8str), &utf8Size, &resultLen, &errorInfo)
+	rc = C.RfcSAPUCToUTF8(uc, (C.uint)(length), (*C.RFC_BYTE)(unsafe.Pointer(utf8str)), &utf8Size, &resultLen, &errorInfo)
 	if rc != C.RFC_OK {
 		return result, rfcError(errorInfo, "Failed wrapping a C string")
 	}

--- a/gorfc/gorfc_test.go
+++ b/gorfc/gorfc_test.go
@@ -28,9 +28,7 @@ func isValueInList(value string, list []string) bool {
 //
 func TestNWRFCLibVersion(t *testing.T) {
 	major, minor, patchlevel := GetNWRFCLibVersion()
-	assert.Equal(t, uint(7420), major) // adapt to your NW RFC Lib version
-	assert.Equal(t, uint(0), minor)
-	assert.Equal(t, uint(0), patchlevel)
+	assert.Equal(t, "7500.0.5", fmt.Sprintf("%d.%d.%d", major, minor, patchlevel)) // adapt to your NW RFC Lib version
 }
 
 //


### PR DESCRIPTION
Adding support for macOS was straight forward. I only had to add one `unsafe.Pointer` instruction to get rid of the following compiler error:
```
>go build ./gorfc
# github.com/SAP/gorfc/gorfc
gorfc/gorfc.go:291:59: cannot convert utf8str (type *_Ctype_char) to type *_Ctype_uchar
```