### PR TITLE
improve documentation for building with go >=1.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ To install _gorfc_ and dependencies, run following commands:
 ```bash
 export CGO_CFLAGS="-I $SAPNWRFC_HOME/include"
 export CGO_LDFLAGS="-L $SAPNWRFC_HOME/lib"
+export CGO_CFLAGS_ALLOW=.*
+export CGO_LDFLAGS_ALLOW=.*
 go get github.com/stretchr/testify
 go get github.com/sap/gorfc
 cd $GOPATH/src/github.com/sap/gorfc/gorfc


### PR DESCRIPTION
Newer versions of go have a whitelist of allowed compiler and linker flags:
https://github.com/golang/go/wiki/InvalidFlag

This cases compiliation to fail with rather cryptic error messages like:
  go build github.com/SAP/gorfc/gorfc: invalid flag in #cgo LDFLAGS: -minline-all-stringops

As a shorterm fix this commit updates the documentation how to whitelist all flags to get the compilation going again.

Fixes #13 