### PR TITLE
Fix compilation on Darwin

### DIFF
--- a/gorfc/gorfc.go
+++ b/gorfc/gorfc.go
@@ -47,7 +47,7 @@ package gorfc
 // ~~~~ darwin ~~~~ //
 
 #cgo darwin CFLAGS: -Wall -O2 -Wno-uninitialized -Wcast-align
-#cgo darwin CFLAGS: -DSAP_UC_is_wchar -DSAPwithUNICODE -D__NO_MATH_INLINES -DSAPwithTHREADS -DSAPonLIN
+#cgo darwin CFLAGS: -DSAP_UC_is_wchar -DSAPwithUNICODE -D__NO_MATH_INLINES -DSAPwithTHREADS -DSAPonDARW
 #cgo darwin CFLAGS: -fexceptions -funsigned-char -fno-strict-aliasing -fPIC -pthread -std=c17 -mmacosx-version-min=10.15
 #cgo darwin CFLAGS: -fno-omit-frame-pointer
 


### PR DESCRIPTION
with the `SAPonLin` flag compilation on Darwin fails for me with:
```
# github.com/SAP/gorfc/gorfc
In file included from ../../../go/pkg/mod/github.com/!s!a!p/gorfc@v0.1.1-0.20200609111446-a9cb6732d0fe/gorfc/gorfc.go:62:
In file included from .../nwrfcsdk/darwin/nwrfcsdk/include/sapnwrfc.h:7:
.../nwrfcsdk/darwin/nwrfcsdk/include/sapucx.h:303:14: fatal error: 'uchar.h' file not found
    #include <uchar.h>
             ^~~~~~~~~
1 error generated.
```

Darwin: 10.15.5
NWRFCSDK: 7.50